### PR TITLE
Fixing quantity JSON serializer logic in Kubernetes API Model

### DIFF
--- a/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/resource/Quantity.java
+++ b/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/resource/Quantity.java
@@ -112,11 +112,11 @@ public class Quantity {
         @Override
         public void serialize(Quantity value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
             if (value != null && value.getAmount() != null) {
+                jgen.writeNumber(value.getAmount());
             } else {
                 jgen.writeNull();
             }
         }
-
     }
 
     public static class Deserializer extends JsonDeserializer<Quantity> {


### PR DESCRIPTION
First of all thanks for publishing Fabric8 Kubernetes API client as an Open Source library. I found a minor issue in Quantity JSON serializer where it has not written any logic to set the amount value. 

As a result if configuration requests/limits are set to a container a JSON syntax error occurs when creating a Pod.

```
Pod pod = new Pod();
...
ResourceRequirements resources = new ResourceRequirements();
Map<String, Quantity> limits = new HashMap<String, Quantity>();
limits.put("cpu", new Quantity(String.valueOf(cpu)));
resources.setLimits(limits);
containerTemplate.setResources(resources);

List<Container> containerTemplates = new ArrayList<Container>();
containerTemplates.add(containerTemplate);
pod.getSpec().setContainers(containerTemplates);
```